### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mikeee/aws_credential_helper/security/code-scanning/1](https://github.com/mikeee/aws_credential_helper/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily performs tasks like checking out code, setting up Go, downloading dependencies, linting, and running tests, it only requires `contents: read` permissions. This ensures that the workflow has the minimal permissions necessary to function correctly.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs, including `aio`. This approach avoids redundancy and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
